### PR TITLE
Make sure CapacitorSecurityProvider does not override error status

### DIFF
--- a/android/src/main/java/community/capacitor/android/security/provider/CapacitorSecurityProvider.java
+++ b/android/src/main/java/community/capacitor/android/security/provider/CapacitorSecurityProvider.java
@@ -35,9 +35,6 @@ public class CapacitorSecurityProvider {
             status = "GooglePlayServicesNotAvailableException";
         }
 
-        // If this is reached, you know that the provider was already up to date
-        // or was successfully updated.
-        status = "Success";
         return status;
     }
 }


### PR DESCRIPTION
Currently, the status set in the `catch` blocks is always overridden with "Success". That means the method will always return "Success".