### PR TITLE
chore: add dist to .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 example-app
+dist


### PR DESCRIPTION
since in this plugin dist folder is published it causes issues with lint command.
make prettier ignore it.