### PR TITLE
chore: remove all contributors badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,6 @@
 <br>
   <a href="https://www.npmjs.com/package/@capacitor-community/security-provider"><img src="https://img.shields.io/npm/dw/@capacitor-community/security-provider?style=flat-square" /></a>
   <a href="https://www.npmjs.com/package/@capacitor-community/security-provider"><img src="https://img.shields.io/npm/v/@capacitor-community/security-provider?style=flat-square" /></a>
-<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-<a href="#contributors-"><img src="https://img.shields.io/badge/all%20contributors-1-orange?style=flat-square" /></a>
-<!-- ALL-CONTRIBUTORS-BADGE:END -->
 </p>
 
 ## About


### PR DESCRIPTION
The plugin is not using all contributors and has no contributors section on the README, so remove the badge